### PR TITLE
Fix compatibility with Django 3.2+/4+/5+ and Elasticsearch 7+

### DIFF
--- a/rubber/__init__.py
+++ b/rubber/__init__.py
@@ -1,8 +1,13 @@
 """
 Init for rubber.
 """
+import django
+
 from .version import __version__  # noqa
 
 from rubber.apps import get_rubber_config  # noqa
 
-default_app_config = 'rubber.apps.RubberConfig'
+# default_app_config is deprecated in Django 3.2+ (auto-discovery)
+# but required for Django 3.0/3.1
+if django.VERSION < (3, 2):
+    default_app_config = 'rubber.apps.RubberConfig'

--- a/rubber/apps.py
+++ b/rubber/apps.py
@@ -1,11 +1,10 @@
 """
 App config for rubber.
 """
+from collections.abc import Mapping
 from copy import deepcopy
-import collections
 
 import logging
-import six
 
 from elasticsearch import Elasticsearch
 
@@ -17,10 +16,7 @@ from django.db.models.signals import post_save
 
 logger = logging.getLogger(__name__)
 
-try:
-    from django.apps import AppConfig
-except ImportError:
-    AppConfig = object
+from django.apps import AppConfig
 
 
 DEFAULT_RUBBER = {
@@ -36,8 +32,8 @@ DEFAULT_RUBBER = {
 
 
 def recursive_update(d, u):
-    for k, v in six.iteritems(u):
-        if isinstance(v, collections.Mapping):
+    for k, v in u.items():
+        if isinstance(v, Mapping):
             r = recursive_update(d.get(k, {}), v)
             d[k] = r
         else:
@@ -63,7 +59,13 @@ def post_save_es_index(sender, instance, **kwargs):
 
 
 def post_delete_es_delete(sender, instance, **kwargs):
-    instance.es_delete()
+    try:
+        instance.es_delete()
+    except Exception:
+        logger.error(
+            "Exception occurred in post_delete_es_delete.",
+            exc_info=True
+        )
 
 
 def class_prepared_check_indexable(sender, **kwargs):
@@ -94,7 +96,7 @@ class RubberConfig(AppConfig):
 
     def __init__(self, *args, **kwargs):
         class_prepared.connect(class_prepared_check_indexable)
-        super(RubberConfig, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def ready(self):
         self._es = Elasticsearch(hosts=self.hosts)
@@ -147,16 +149,6 @@ class RubberConfig(AppConfig):
     def config_root(self):
         return self.settings['CONFIG_ROOT']
 
-try:
-    # Try to import AppConfig to check if this feature is available.
-    from django.apps import AppConfig  # noqa
-except ImportError:
-    app_config = RubberConfig()
-    app_config.ready()
-
-    def get_rubber_config():
-        return app_config
-else:
-    def get_rubber_config():
-        from django.apps import apps
-        return apps.get_app_config('rubber')
+def get_rubber_config():
+    from django.apps import apps
+    return apps.get_app_config('rubber')

--- a/rubber/management/base.py
+++ b/rubber/management/base.py
@@ -1,12 +1,8 @@
 """
 Base management command for rubber.
 """
-from __future__ import print_function
-from optparse import make_option
 import sys
 import traceback
-
-import six
 
 from django.core.management.base import BaseCommand
 
@@ -45,7 +41,7 @@ class ESBaseCommand(BaseCommand):
                     required_option))
                 sys.exit(1)
 
-        for key, value in six.iteritems(options):
+        for key, value in options.items():
             setattr(self, key, value)
 
         try:
@@ -70,12 +66,9 @@ class ESBaseCommand(BaseCommand):
     def confirm(self, message):  # pragma: no cover
         if self.yes:
             return True
-        message += u" [Y/n]"
+        message += " [Y/n]"
         self.print_warning(message)
-        try:
-            choice = raw_input()
-        except NameError:
-            choice = input()
+        choice = input()
         if choice != 'Y':
             self.print_error("Operation canceled.")
             sys.exit(1)
@@ -86,17 +79,17 @@ class ESBaseCommand(BaseCommand):
 
     def print_info(self, message, verbosity=1):
         if self.verbosity >= verbosity:
-            print(u"{0}{1}{2}".format(self.BLUE, message, self.RESET))
+            print("{0}{1}{2}".format(self.BLUE, message, self.RESET))
 
     def print_success(self, message, verbosity=1):
         if self.verbosity >= verbosity:
-            print(u"{0}{1}{2}".format(self.GREEN, message, self.RESET))
+            print("{0}{1}{2}".format(self.GREEN, message, self.RESET))
 
     def print_error(self, message):
         print(
-            u"{0}{1}{2}".format(self.RED, message, self.RESET),
+            "{0}{1}{2}".format(self.RED, message, self.RESET),
             file=sys.stderr
         )
 
     def print_warning(self, message):  # pragma: no cover
-        print(u"{0}{1}{2}".format(self.YELLOW, message, self.RESET))
+        print("{0}{1}{2}".format(self.YELLOW, message, self.RESET))

--- a/rubber/management/commands/es_create_documents.py
+++ b/rubber/management/commands/es_create_documents.py
@@ -2,7 +2,6 @@
 Management command for rubber.
 """
 from datetime import datetime
-from optparse import make_option
 import concurrent.futures as futures
 import sys
 
@@ -71,21 +70,20 @@ class Command(ESBaseCommand):
             sys.exit(1)
         else:
             return from_date
-        return None
 
     def run(self, *args, **options):
         from_date = self.get_from_date()
         if from_date is not None:
-            self.print_info(u"Reference date : {0}".format(from_date))
+            self.print_info("Reference date : {0}".format(from_date))
 
         models_paths = self.get_models_paths()
         indexable_models = self.rubber_config.get_models_from_paths(
             models_paths)
-        self.print_info(u"Models : {0}".format(indexable_models))
+        self.print_info("Models : {0}".format(indexable_models))
 
         for model in indexable_models:
             self.print_success(
-                u"Indexing model: '{0}'.".format(model.__name__))
+                "Indexing model: '{0}'.".format(model.__name__))
             queryset = model.get_indexable_queryset()
 
             if from_date is not None and model.es_reference_date is not None:
@@ -115,7 +113,7 @@ class Command(ESBaseCommand):
                     if self.show_tqdm:
                         pbar.update(1)
                 try:
-                    body = u"\n".join(requests)
+                    body = "\n".join(requests)
                     if not self.dry_run:
                         self.rubber_config.es.bulk(body=body)
                 except Exception as exc:

--- a/rubber/management/commands/es_create_index.py
+++ b/rubber/management/commands/es_create_index.py
@@ -36,7 +36,7 @@ class Command(ESBaseCommand):
                 self.rubber_config.config_root,
                 '{0}.json'.format(index)
             )
-            self.print_info(u"Using config file : {0}".format(config_path))
+            self.print_info("Using config file : {0}".format(config_path))
             body = None
             try:
                 with open(config_path, 'r') as f:
@@ -45,4 +45,4 @@ class Command(ESBaseCommand):
                 self.print_error("Config file does not exist.")
                 continue
             self.rubber_config.es.indices.create(index=index, body=body)
-            self.print_success(u"Index {0} created.".format(index))
+            self.print_success("Index {0} created.".format(index))

--- a/rubber/mixins.py
+++ b/rubber/mixins.py
@@ -47,19 +47,17 @@ class ESIndexableMixin(object):
         version = indexer.get('version')
         if 'dsl_doc_type' in indexer:
             index = indexer['dsl_doc_type']._index._name
-            doc_type = indexer['dsl_doc_type']._doc_type.name
         else:
             index = indexer['index']
-            doc_type = indexer['doc_type']
         if version is not None:
             index = '{0}_v{1}'.format(index, version)
-        return (index, doc_type, version)
+        return (index, version)
 
     def get_es_doc(self, indexer_key):
         if not self.pk:
             return None
         indexer = self.get_es_indexers()[indexer_key]
-        index, doc_type, version = self.get_es_indexer_meta(indexer)
+        index, version = self.get_es_indexer_meta(indexer)
         result = rubber_config.es.get(
             index=index,
             id=self.pk,
@@ -70,9 +68,11 @@ class ESIndexableMixin(object):
         return result
 
     def get_es_index_body(self):
+        if not self.pk:
+            return None
         requests = []
-        for _, indexer in iter(self.get_es_indexers().items()):
-            index, doc_type, version = self.get_es_indexer_meta(indexer)
+        for _, indexer in self.get_es_indexers().items():
+            index, version = self.get_es_indexer_meta(indexer)
             requests.append({
                 'index': {
                     '_index': index,
@@ -85,21 +85,21 @@ class ESIndexableMixin(object):
             else:
                 body = indexer['serializer'](self, context={'request': None}).data
                 requests.append(body)
-        return u"\n".join([
+        return "\n".join([
             dsl_serializer.dumps(request) for request in requests
         ])
 
     def get_es_delete_body(self):
         requests = []
-        for _, indexer in iter(self.get_es_indexers().items()):
-            index, doc_type, version = self.get_es_indexer_meta(indexer)
+        for _, indexer in self.get_es_indexers().items():
+            index, version = self.get_es_indexer_meta(indexer)
             requests.append({
                 'delete': {
                     '_index': index,
                     '_id': self.pk
                 }
             })
-        return u"\n".join([json.dumps(request, cls=EnhancedJsonEncoder) for request in requests])
+        return "\n".join([json.dumps(request, cls=EnhancedJsonEncoder) for request in requests])
 
     def es_index(self, is_async=True, countdown=0):
         if rubber_config.is_disabled or not self.is_indexable():

--- a/rubber/tasks.py
+++ b/rubber/tasks.py
@@ -20,10 +20,10 @@ def es_bulk(body, fail_silently=None):
         fail_silently = rubber_config.should_fail_silently
     try:
         rubber_config.es.bulk(body=body)
-    except:
+    except Exception:
         if fail_silently:
             logger.error(
-                "Exception occured in es_bulk.",
+                "Exception occurred in es_bulk.",
                 exc_info=True,
                 extra={'body': body}
             )
@@ -41,10 +41,10 @@ def es_index_object(content_type_id, object_id, fail_silently=None):
         if not obj.is_indexable():
             return
         rubber_config.es.bulk(body=obj.get_es_index_body())
-    except:
+    except Exception:
         if fail_silently:
             logger.error(
-                "Exception occured while indexing object.",
+                "Exception occurred while indexing object.",
                 exc_info=True,
                 extra={
                     'content_type_id': content_type_id,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 """
 Setup for rubber.
 """
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 
@@ -12,11 +10,8 @@ install_requires = [
     'elasticsearch',
     'elasticsearch-dsl',
     'celery',
-    'six',
     'tqdm',
 ]
-if sys.version_info.major == 2:
-    install_requires.append('futures')
 
 setup(
     name='django-rubber',

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,7 +11,7 @@ rubber_config = get_rubber_config()
 class BaseTestCase(TransactionTestCase):
 
     def setUp(self):
-        super(BaseTestCase, self).setUp()
+        super().setUp()
         self.rubber_config = rubber_config
 
     def refresh(self):
@@ -31,12 +31,6 @@ class BaseTestCase(TransactionTestCase):
     def indexExists(self, index):
         return rubber_config.es.indices.exists(index=index)
 
-    def typeExists(self, index, doc_type):
-        return rubber_config.es.indices.exists_type(
-            index=index,
-            doc_type=doc_type
-        )
-
     def assertAliasExists(self, index, name):
         self.assertTrue(self.aliasExists(index, name))
 
@@ -48,12 +42,6 @@ class BaseTestCase(TransactionTestCase):
 
     def assertIndexDoesntExist(self, index):
         self.assertFalse(self.indexExists(index))
-
-    def assertTypeExists(self, index, doc_type):
-        self.assertTrue(self.typeExists(index, doc_type))
-
-    def assertTypeDoesntExist(self, index, doc_type):
-        self.assertFalse(self.typeExists(index, doc_type))
 
     def assertDocExists(self, obj, indexer_index):
         self.assertTrue(self.docExists(obj, indexer_index))

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,9 +14,6 @@ class TokenDocType(Document):
     number = Text()
     multi = Text(multi=True)
 
-    class Meta:
-        doc_type = 'token'
-
     class Index:
         name = 'index_2'
 
@@ -42,7 +39,7 @@ class Token(ESIndexableMixin, models.Model):
     name = models.CharField(default='token', max_length=200)
     number = models.IntegerField(default=42)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def get_es_indexers(self):
@@ -51,7 +48,6 @@ class Token(ESIndexableMixin, models.Model):
                 'version': 1,
                 'index': 'index_1',
                 'serializer': TokenSerializer,
-                'doc_type': 'token'
             },
             'INDEX_2': {
                 'version': 1,


### PR DESCRIPTION
- Replace collections.Mapping with collections.abc.Mapping (broken in Python 3.10+)
- Remove all doc_type references (removed in ES 7)
- Remove six dependency and Python 2 compatibility code
- Fix bare except clauses to use except Exception
- Add error handling in post_delete signal handler
- Add self.pk check in get_es_index_body()
- Make default_app_config conditional (Django < 3.2 only)
- Clean up u"" string literals and raw_input fallback
- Remove unreachable code and unused imports